### PR TITLE
Create multi-page Trois Six Neuf studio website

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Meet Trois Six Neuf | A Studio Built for Creators</title>
+    <meta
+      name="description"
+      content="Learn about our vision, tech-first philosophy, and creative roots."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a href="index.html" class="brand">Trois Six Neuf</a>
+        <nav aria-label="Primary">
+          <ul id="primary-menu" class="nav-links">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="studio-spaces.html">Studio Spaces</a></li>
+            <li><a href="creative-services.html">Creative Services</a></li>
+            <li><a class="active" href="about.html">About</a></li>
+            <li><a href="book-now.html">Book Now</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <a class="btn btn-primary" href="book-now.html">Book a Session</a>
+        <button class="hamburger" aria-label="Toggle navigation" aria-controls="primary-menu" aria-expanded="false">
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" style="min-height: 70vh;">
+        <div
+          class="hero-visual"
+          style="background-image: url('https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1500&q=80');"
+          aria-hidden="true"
+        ></div>
+        <div class="hero-content" data-animate>
+          <div class="badge">Our story</div>
+          <h1>A lab built by creators, for creators</h1>
+          <p>
+            Trois Six Neuf emerged from a collective of filmmakers, designers, and technologists who wanted a studio that answered modern production realities without compromising artistry.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container about-hero">
+          <div>
+            <h2 class="section-title">Vision &amp; philosophy</h2>
+            <p class="muted">
+              We believe the studio should be a catalyst — a space where ideas move as fast as inspiration. Our workflow-first design bridges the gap between creative ambition and technical execution, empowering teams to iterate, test, and capture without friction.
+            </p>
+          </div>
+          <div class="card">
+            <h3>Built for professionals</h3>
+            <p class="muted">From ruggedized power to fiber connectivity, every detail supports crews operating at broadcast and cinematic standards.</p>
+            <h3 style="margin-top: 1.5rem;">Hospitality meets precision</h3>
+            <p class="muted">We curate the environment with tailored amenities, concierge support, and cultural warmth to keep your talent and clients energized.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container">
+          <blockquote class="quote">We designed Trois Six Neuf to be more than a space — it’s a catalyst.</blockquote>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container split-grid">
+          <div class="card">
+            <h3>Founders</h3>
+            <p class="muted">A trio of creatives spanning cinematography, sound engineering, and culinary storytelling. We merged our disciplines to craft a playground for innovation in Casablanca.</p>
+          </div>
+          <div class="card">
+            <h3>Behind the scenes</h3>
+            <p class="muted">Peek into lighting labs, equipment prep zones, and control rooms where our team calibrates every production touchpoint.</p>
+          </div>
+          <div class="card">
+            <h3>Community</h3>
+            <p class="muted">We host workshops, listening sessions, and chef residencies to keep the Trois Six Neuf network pulsing with fresh talent.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container team-grid">
+          <div class="team-card">
+            <h4>Salim</h4>
+            <p class="muted">Creative Director &amp; Cinematographer</p>
+          </div>
+          <div class="team-card">
+            <h4>Anissa</h4>
+            <p class="muted">Head of Production &amp; Sound</p>
+          </div>
+          <div class="team-card">
+            <h4>Youssef</h4>
+            <p class="muted">Culinary Producer &amp; Experience Lead</p>
+          </div>
+          <div class="team-card">
+            <h4>Extended Crew</h4>
+            <p class="muted">Trusted cinematographers, editors, colorists, and stylists on-call for every scope.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <div class="footer-brand">Trois Six Neuf</div>
+          <p class="muted">Casablanca's high-end creative and production boutique studio.</p>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <p class="muted">36 Rue de la Réunion, Casablanca</p>
+        </div>
+        <div>
+          <h4>Quick Links</h4>
+          <div class="footer-links">
+            <a href="studio-spaces.html">Studio Spaces</a>
+            <a href="creative-services.html">Services</a>
+            <a href="book-now.html">Book Now</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h4>Connect</h4>
+          <div class="social-links">
+            <a href="https://www.instagram.com/trois.six.neuf" target="_blank" rel="noreferrer">Instagram</a>
+            <a href="mailto:trois6neuf.studio@gmail.com">Email</a>
+          </div>
+          <a href="book-now.html" class="muted" style="display: inline-block; margin-top: 0.8rem;">Booking Policy</a>
+        </div>
+      </div>
+      <div class="container footer-bottom">
+        <span>© <span id="year"></span> Trois Six Neuf Studio.</span>
+        <span>Crafted for creators in Casablanca.</span>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,721 @@
+:root {
+  --color-primary: #d42027;
+  --color-accent: #d1bc80;
+  --color-black: #0f0f0f;
+  --color-white: #ffffff;
+  --color-grey: #1f1f1f;
+  --color-muted: #f4f1ea;
+  --font-heading: "Space Grotesk", "Neue Haas Grotesk", "Helvetica Neue", Arial, sans-serif;
+  --font-body: "Inter", "Helvetica Neue", Arial, sans-serif;
+  --max-width: 1200px;
+  --transition: all 0.3s ease;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--color-black);
+  color: var(--color-white);
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+button:hover {
+  cursor: pointer;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(90%, var(--max-width));
+  margin: 0 auto;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  backdrop-filter: blur(14px);
+  background: rgba(15, 15, 15, 0.88);
+  border-bottom: 1px solid rgba(209, 188, 128, 0.2);
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.2rem 0;
+}
+
+.brand {
+  font-family: var(--font-heading);
+  font-size: 1.4rem;
+  letter-spacing: 0.2rem;
+  text-transform: uppercase;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  list-style: none;
+}
+
+.nav-links a {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  position: relative;
+}
+
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.4rem;
+  width: 100%;
+  height: 2px;
+  background: var(--color-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: var(--transition);
+}
+
+.nav-links a:hover::after,
+.nav-links a:focus::after,
+.nav-links a.active::after {
+  transform: scaleX(1);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.6rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  transition: var(--transition);
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: var(--color-white);
+}
+
+.btn-primary:hover {
+  background: transparent;
+  border-color: var(--color-primary);
+}
+
+.btn-outline {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.btn-outline:hover {
+  background: var(--color-accent);
+  color: var(--color-black);
+}
+
+.hamburger {
+  display: none;
+  width: 2.2rem;
+  height: 2.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  transition: var(--transition);
+}
+
+.hamburger span {
+  display: block;
+  width: 1.2rem;
+  height: 2px;
+  background: var(--color-white);
+  position: relative;
+}
+
+.hamburger span::before,
+.hamburger span::after {
+  content: "";
+  position: absolute;
+  width: 1.2rem;
+  height: 2px;
+  background: var(--color-white);
+  left: 0;
+  transition: var(--transition);
+}
+
+.hamburger span::before {
+  top: -0.4rem;
+}
+
+.hamburger span::after {
+  top: 0.4rem;
+}
+
+.hamburger.active span {
+  background: transparent;
+}
+
+.hamburger.active span::before {
+  transform: rotate(45deg);
+  top: 0;
+}
+
+.hamburger.active span::after {
+  transform: rotate(-45deg);
+  top: 0;
+}
+
+.hero {
+  position: relative;
+  min-height: 90vh;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(212, 32, 39, 0.45), transparent 50%),
+    radial-gradient(circle at bottom right, rgba(209, 188, 128, 0.25), transparent 55%),
+    linear-gradient(135deg, rgba(15, 15, 15, 0.95), rgba(15, 15, 15, 0.7));
+  z-index: 1;
+}
+
+.hero video,
+.hero .hero-visual {
+  position: absolute;
+  inset: 0;
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+  filter: saturate(1.2) brightness(0.5);
+  transform: scale(1.05);
+}
+
+.hero .hero-visual {
+  background: url('https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1500&q=80') center/cover;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 2;
+  padding: 4rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.8rem, 8vw, 5.5rem);
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+  line-height: 1.05;
+}
+
+.hero p {
+  max-width: 40rem;
+  margin: 0 auto;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.hero-cta {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.section {
+  padding: clamp(4rem, 6vw, 7rem) 0;
+}
+
+.section-title {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.2rem);
+  margin-bottom: 2.5rem;
+  text-transform: uppercase;
+  letter-spacing: -0.04em;
+}
+
+.split-grid {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
+}
+
+.card {
+  background: linear-gradient(135deg, rgba(209, 188, 128, 0.07), rgba(255, 255, 255, 0.03));
+  border: 1px solid rgba(209, 188, 128, 0.2);
+  padding: 2rem;
+  border-radius: 1.2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  background: linear-gradient(135deg, rgba(212, 32, 39, 0.45), rgba(15, 15, 15, 0));
+  opacity: 0;
+  transition: var(--transition);
+  z-index: 0;
+}
+
+.card:hover::before {
+  opacity: 1;
+}
+
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.icon-circle {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: grid;
+  place-items: center;
+  margin-bottom: 1.5rem;
+  background: rgba(212, 32, 39, 0.2);
+}
+
+.icon-circle span {
+  font-size: 1.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08rem;
+  font-size: 0.75rem;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.muted {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.grid-logos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+  align-items: center;
+  justify-items: center;
+}
+
+.logo-tile {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 1.4rem;
+  border-radius: 1rem;
+  text-align: center;
+  font-family: var(--font-heading);
+  letter-spacing: 0.12rem;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  background: rgba(15, 15, 15, 0.6);
+}
+
+.feature-list {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.feature-list li {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-weight: 500;
+}
+
+.feature-list li::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  background: radial-gradient(circle, var(--color-primary), transparent 60%);
+  border-radius: 50%;
+}
+
+.parallax-section {
+  position: relative;
+  overflow: hidden;
+  background: url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1500&q=80') center/cover fixed;
+}
+
+.parallax-section::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 15, 15, 0.75);
+}
+
+.parallax-section .container {
+  position: relative;
+  z-index: 1;
+}
+
+.studio-grid {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.studio {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+}
+
+.studio-visual {
+  min-height: 260px;
+  border-radius: 1.2rem;
+  overflow: hidden;
+  position: relative;
+  background: rgba(15, 15, 15, 0.8);
+}
+
+.studio-visual::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(212, 32, 39, 0.5), rgba(209, 188, 128, 0.2));
+  mix-blend-mode: screen;
+  opacity: 0.4;
+}
+
+.studio-visual img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(1.1);
+}
+
+.studio h3 {
+  font-family: var(--font-heading);
+  font-size: 2rem;
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+}
+
+.studio p {
+  color: rgba(255, 255, 255, 0.74);
+}
+
+.package-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.package-card {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.1rem;
+  padding: 2rem;
+  background: rgba(15, 15, 15, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: var(--transition);
+}
+
+.package-card:hover {
+  transform: translateY(-6px);
+  border-color: var(--color-primary);
+}
+
+.service-list {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.service-card {
+  position: relative;
+  padding: 2.5rem 2rem;
+  border-radius: 1.4rem;
+  overflow: hidden;
+  border: 1px solid rgba(209, 188, 128, 0.25);
+  background: rgba(15, 15, 15, 0.72);
+  transition: var(--transition);
+}
+
+.service-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(209, 188, 128, 0.3), transparent 60%);
+  opacity: 0;
+  transition: var(--transition);
+}
+
+.service-card:hover {
+  transform: translateY(-8px);
+}
+
+.service-card:hover::after {
+  opacity: 1;
+}
+
+.about-hero {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.quote {
+  font-family: var(--font-heading);
+  font-size: 1.8rem;
+  line-height: 1.2;
+  position: relative;
+  padding-left: 3rem;
+}
+
+.quote::before {
+  content: "\201C";
+  position: absolute;
+  left: 0;
+  top: -0.4rem;
+  font-size: 3rem;
+  color: var(--color-primary);
+}
+
+.team-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.team-card {
+  background: rgba(15, 15, 15, 0.8);
+  padding: 1.5rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.highlight {
+  color: var(--color-accent);
+}
+
+iframe {
+  border: none;
+}
+
+.faq {
+  display: grid;
+  gap: 1rem;
+}
+
+.faq-item {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  background: rgba(15, 15, 15, 0.7);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.form-grid label {
+  display: block;
+  font-size: 0.85rem;
+  letter-spacing: 0.08rem;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.form-grid input,
+.form-grid textarea {
+  width: 100%;
+  padding: 1rem;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(15, 15, 15, 0.7);
+  color: var(--color-white);
+  font-family: var(--font-body);
+}
+
+.form-grid input:focus,
+.form-grid textarea:focus {
+  outline: 1px solid var(--color-primary);
+}
+
+footer {
+  padding: 3rem 0 2rem;
+  background: rgba(15, 15, 15, 0.95);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.footer-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.footer-brand {
+  font-family: var(--font-heading);
+  letter-spacing: 0.12rem;
+  text-transform: uppercase;
+}
+
+.footer-links {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.social-links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.footer-bottom {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.scroll-indicator {
+  position: absolute;
+  bottom: 3rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1px;
+  height: 70px;
+  background: linear-gradient(to bottom, transparent, rgba(255, 255, 255, 0.7));
+  overflow: hidden;
+}
+
+.scroll-indicator::after {
+  content: "";
+  position: absolute;
+  top: -50%;
+  left: 0;
+  width: 1px;
+  height: 50%;
+  background: var(--color-primary);
+  animation: scrollPulse 2.5s infinite;
+}
+
+@keyframes scrollPulse {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(140%);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .nav-links {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 15, 15, 0.96);
+    flex-direction: column;
+    padding: 6rem 2rem;
+    transform: translateX(100%);
+    transition: var(--transition);
+  }
+
+  .nav-links.open {
+    transform: translateX(0);
+  }
+
+  .hamburger {
+    display: inline-flex;
+  }
+
+  .nav-links li {
+    width: 100%;
+    text-align: center;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    padding-bottom: 1rem;
+  }
+
+  .hero-cta {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 600px) {
+  .navbar {
+    padding: 1rem 0;
+  }
+
+  .section {
+    padding: 3.5rem 0;
+  }
+
+  .card,
+  .package-card,
+  .service-card,
+  .faq-item {
+    padding: 1.6rem;
+  }
+}
+
+[data-animate] {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+[data-animate].in-view {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+body.nav-open {
+  overflow: hidden;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,43 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const hamburger = document.querySelector(".hamburger");
+  const navLinks = document.querySelector(".nav-links");
+  const navLinkItems = document.querySelectorAll(".nav-links a");
+
+  if (hamburger && navLinks) {
+    hamburger.setAttribute("aria-expanded", "false");
+
+    hamburger.addEventListener("click", () => {
+      hamburger.classList.toggle("active");
+      navLinks.classList.toggle("open");
+      document.body.classList.toggle("nav-open");
+      const expanded = hamburger.classList.contains("active");
+      hamburger.setAttribute("aria-expanded", expanded ? "true" : "false");
+    });
+
+    navLinkItems.forEach((link) =>
+      link.addEventListener("click", () => {
+        hamburger.classList.remove("active");
+        navLinks.classList.remove("open");
+        document.body.classList.remove("nav-open");
+        hamburger.setAttribute("aria-expanded", "false");
+      })
+    );
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("in-view");
+        }
+      });
+    },
+    {
+      threshold: 0.2,
+    }
+  );
+
+  document.querySelectorAll("[data-animate]").forEach((section) => {
+    observer.observe(section);
+  });
+});

--- a/book-now.html
+++ b/book-now.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Book Your Studio Session | Trois Six Neuf</title>
+    <meta
+      name="description"
+      content="Reserve your space at Trois Six Neuf with real-time availability and modular packages."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a href="index.html" class="brand">Trois Six Neuf</a>
+        <nav aria-label="Primary">
+          <ul id="primary-menu" class="nav-links">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="studio-spaces.html">Studio Spaces</a></li>
+            <li><a href="creative-services.html">Creative Services</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a class="active" href="book-now.html">Book Now</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <a class="btn btn-primary" href="book-now.html">Book a Session</a>
+        <button class="hamburger" aria-label="Toggle navigation" aria-controls="primary-menu" aria-expanded="false">
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" style="min-height: 60vh;">
+        <div
+          class="hero-visual"
+          style="background-image: url('https://images.unsplash.com/photo-1516637090014-cb1ab0d08fc7?auto=format&fit=crop&w=1500&q=80');"
+          aria-hidden="true"
+        ></div>
+        <div class="hero-content" data-animate>
+          <div class="badge">Book your session</div>
+          <h1>Live availability &amp; concierge coordination</h1>
+          <p>
+            Lock in your preferred studio slot via Setmore. Our production team will confirm details, equipment, and any crew support you need within hours.
+          </p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="https://troissixneufstudio.setmore.com" target="_blank" rel="noreferrer">Launch booking portal</a>
+            <a class="btn btn-outline" href="#faq">Review policies</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container">
+          <h2 class="section-title">Real-time scheduling</h2>
+          <p class="muted" style="max-width: 40rem;">
+            Use the embedded calendar for instant reservations, or open the Setmore portal in a new window for a full-screen experience.
+          </p>
+          <div style="margin-top: 2rem; border-radius: 1.2rem; overflow: hidden; border: 1px solid rgba(209, 188, 128, 0.2);">
+            <iframe
+              src="https://troissixneufstudio.setmore.com"
+              title="Trois Six Neuf Booking"
+              style="width: 100%; min-height: 720px; background-color: #0f0f0f;"
+            ></iframe>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="faq" data-animate>
+        <div class="container">
+          <h2 class="section-title">Booking essentials</h2>
+          <div class="faq">
+            <div class="faq-item">
+              <h3>What should we bring?</h3>
+              <p class="muted">Bring your creative team, talent, and any custom props. Let us know if you need additional gear and we will prepare it ahead of arrival.</p>
+            </div>
+            <div class="faq-item">
+              <h3>How much setup time is included?</h3>
+              <p class="muted">Each booking includes a 60-minute setup buffer and a 30-minute wrap window. Additional setup can be arranged upon request.</p>
+            </div>
+            <div class="faq-item">
+              <h3>Is support staff available?</h3>
+              <p class="muted">Absolutely. Request studio managers, camera operators, gaffers, or culinary stylists when you confirm the session and we’ll align the crew.</p>
+            </div>
+            <div class="faq-item">
+              <h3>What is the booking policy?</h3>
+              <p class="muted">A 50% deposit is required to secure the slot. Reschedules are accepted with 72 hours’ notice. Full policy details are shared upon confirmation.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <div class="footer-brand">Trois Six Neuf</div>
+          <p class="muted">Casablanca's high-end creative and production boutique studio.</p>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <p class="muted">36 Rue de la Réunion, Casablanca</p>
+        </div>
+        <div>
+          <h4>Quick Links</h4>
+          <div class="footer-links">
+            <a href="studio-spaces.html">Studio Spaces</a>
+            <a href="creative-services.html">Services</a>
+            <a href="book-now.html">Book Now</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h4>Connect</h4>
+          <div class="social-links">
+            <a href="https://www.instagram.com/trois.six.neuf" target="_blank" rel="noreferrer">Instagram</a>
+            <a href="mailto:trois6neuf.studio@gmail.com">Email</a>
+          </div>
+          <a href="book-now.html" class="muted" style="display: inline-block; margin-top: 0.8rem;">Booking Policy</a>
+        </div>
+      </div>
+      <div class="container footer-bottom">
+        <span>© <span id="year"></span> Trois Six Neuf Studio.</span>
+        <span>Crafted for creators in Casablanca.</span>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What should we bring?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Bring your creative team, talent, and any custom props. Let us know if you need additional gear and we will prepare it ahead of arrival."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How much setup time is included?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Each booking includes a 60-minute setup buffer and a 30-minute wrap window. Additional setup can be arranged upon request."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is support staff available?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Request studio managers, camera operators, gaffers, or culinary stylists when you confirm the session and we’ll align the crew."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is the booking policy?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "A 50% deposit is required to secure the slot. Reschedules are accepted with 72 hours’ notice. Full policy details are shared upon confirmation."
+            }
+          }
+        ]
+      }
+    </script>
+  </body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Get in Touch with Trois Six Neuf Studio</title>
+    <meta
+      name="description"
+      content="Contact us for bookings, collaborations, and studio tours."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a href="index.html" class="brand">Trois Six Neuf</a>
+        <nav aria-label="Primary">
+          <ul id="primary-menu" class="nav-links">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="studio-spaces.html">Studio Spaces</a></li>
+            <li><a href="creative-services.html">Creative Services</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="book-now.html">Book Now</a></li>
+            <li><a class="active" href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <a class="btn btn-primary" href="book-now.html">Book a Session</a>
+        <button class="hamburger" aria-label="Toggle navigation" aria-controls="primary-menu" aria-expanded="false">
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" style="min-height: 60vh;">
+        <div
+          class="hero-visual"
+          style="background-image: url('https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=1500&q=80');"
+          aria-hidden="true"
+        ></div>
+        <div class="hero-content" data-animate>
+          <div class="badge">Connect with the studio</div>
+          <h1>Start your project with us</h1>
+          <p>
+            Our team is ready to support productions, partnerships, and tours of the Trois Six Neuf ecosystem. Share your vision and we’ll align the right space, equipment, and crew.
+          </p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="mailto:trois6neuf.studio@gmail.com">Email the team</a>
+            <a class="btn btn-outline" href="book-now.html">Book a session</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container split-grid">
+          <div class="card">
+            <h2 class="section-title" style="margin-bottom: 1.5rem;">Visit the studio</h2>
+            <p class="muted">📍 36 Rue de la Réunion, Casablanca</p>
+            <p class="muted">📞 05222-04315</p>
+            <p class="muted">✉️ <a href="mailto:trois6neuf.studio@gmail.com">trois6neuf.studio@gmail.com</a></p>
+            <p class="muted">Instagram: <a href="https://www.instagram.com/trois.six.neuf" target="_blank" rel="noreferrer">@trois.six.neuf</a></p>
+          </div>
+          <div style="border-radius: 1.2rem; overflow: hidden; border: 1px solid rgba(209, 188, 128, 0.2);">
+            <iframe
+              title="Trois Six Neuf Studio Map"
+              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3316.370036928124!2d-7.632553123955779!3d33.59495874232132!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xda7cd3624ff2d21%3A0x4f2e9ca1a2dd9f5c!2s36%20Rue%20de%20la%20R%C3%A9union%2C%20Casablanca%2020200!5e0!3m2!1sen!2sma!4v1700000000000!5m2!1sen!2sma"
+              style="border: 0; width: 100%; min-height: 320px;"
+              allowfullscreen=""
+              loading="lazy"
+              referrerpolicy="no-referrer-when-downgrade"
+            ></iframe>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container split-grid">
+          <div class="card">
+            <h3>Stay in our orbit</h3>
+            <p class="muted">Latest productions, behind the scenes, and studio drops straight from our feed.</p>
+            <div style="margin-top: 1.5rem; border-radius: 1rem; overflow: hidden;">
+              <iframe
+                src="https://www.instagram.com/trois.six.neuf/embed"
+                title="Trois Six Neuf Instagram"
+                style="width: 100%; min-height: 420px; background-color: #0f0f0f;"
+                loading="lazy"
+              ></iframe>
+            </div>
+          </div>
+          <div class="card">
+            <h3>General inquiry</h3>
+            <p class="muted">Tell us about your concept and we’ll respond within one business day.</p>
+            <form class="form-grid">
+              <label for="contact-name"><span class="muted">Name</span></label>
+              <input id="contact-name" type="text" name="name" placeholder="Your full name" required />
+
+              <label for="contact-email"><span class="muted">Email</span></label>
+              <input id="contact-email" type="email" name="email" placeholder="you@example.com" required />
+
+              <label for="contact-phone"><span class="muted">Phone</span></label>
+              <input id="contact-phone" type="tel" name="phone" placeholder="+212 00 00 00 00" />
+
+              <label for="contact-message"><span class="muted">Project details</span></label>
+              <textarea id="contact-message" name="message" rows="5" placeholder="Tell us about your shoot or event" required></textarea>
+              <button type="submit" class="btn btn-primary">Send inquiry</button>
+            </form>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <div class="footer-brand">Trois Six Neuf</div>
+          <p class="muted">Casablanca's high-end creative and production boutique studio.</p>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <p class="muted">36 Rue de la Réunion, Casablanca</p>
+        </div>
+        <div>
+          <h4>Quick Links</h4>
+          <div class="footer-links">
+            <a href="studio-spaces.html">Studio Spaces</a>
+            <a href="creative-services.html">Services</a>
+            <a href="book-now.html">Book Now</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h4>Connect</h4>
+          <div class="social-links">
+            <a href="https://www.instagram.com/trois.six.neuf" target="_blank" rel="noreferrer">Instagram</a>
+            <a href="mailto:trois6neuf.studio@gmail.com">Email</a>
+          </div>
+          <a href="book-now.html" class="muted" style="display: inline-block; margin-top: 0.8rem;">Booking Policy</a>
+        </div>
+      </div>
+      <div class="container footer-bottom">
+        <span>© <span id="year"></span> Trois Six Neuf Studio.</span>
+        <span>Crafted for creators in Casablanca.</span>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/creative-services.html
+++ b/creative-services.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Visual &amp; Audio Content Services | Trois Six Neuf</title>
+    <meta
+      name="description"
+      content="From visual identity to set design — everything you need to create content that resonates."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a href="index.html" class="brand">Trois Six Neuf</a>
+        <nav aria-label="Primary">
+          <ul id="primary-menu" class="nav-links">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="studio-spaces.html">Studio Spaces</a></li>
+            <li><a class="active" href="creative-services.html">Creative Services</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="book-now.html">Book Now</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <a class="btn btn-primary" href="book-now.html">Book a Session</a>
+        <button class="hamburger" aria-label="Toggle navigation" aria-controls="primary-menu" aria-expanded="false">
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" style="min-height: 70vh;">
+        <div
+          class="hero-visual"
+          style="background-image: url('https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1500&q=80');"
+          aria-hidden="true"
+        ></div>
+        <div class="hero-content" data-animate>
+          <div class="badge">Creative direction &amp; production</div>
+          <h1>Services that accelerate your storytelling</h1>
+          <p>
+            Our in-house creatives collaborate with your team to shape narratives, craft visuals, and deliver experiences that resonate from first frame to final mix.
+          </p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="#services">Explore services</a>
+            <a class="btn btn-outline" href="book-now.html">Book a consultation</a>
+          </div>
+        </div>
+      </section>
+
+      <section id="services" class="section" data-animate>
+        <div class="container">
+          <h2 class="section-title">Full-stack creative support</h2>
+          <div class="service-list">
+            <div class="service-card">
+              <div class="icon-circle"><span>✺</span></div>
+              <h3>Content creation support</h3>
+              <p class="muted">Producers, directors, and crew that plug into your project to execute hero campaigns or rapid sprints.</p>
+            </div>
+            <div class="service-card">
+              <div class="icon-circle"><span>⌘</span></div>
+              <h3>Visual identity design</h3>
+              <p class="muted">Brand systems, motion packs, and broadcast toolkits tailored for digital-first storytelling.</p>
+            </div>
+            <div class="service-card">
+              <div class="icon-circle"><span>◍</span></div>
+              <h3>Audio post-production</h3>
+              <p class="muted">Mixing, mastering, and sound design suites for podcasts, commercials, and immersive experiences.</p>
+            </div>
+            <div class="service-card">
+              <div class="icon-circle"><span>▭</span></div>
+              <h3>Set design &amp; styling</h3>
+              <p class="muted">Spatial design, prop sourcing, and art direction to translate concept into tactile environments.</p>
+            </div>
+            <div class="service-card">
+              <div class="icon-circle"><span>⚡</span></div>
+              <h3>Production add-ons</h3>
+              <p class="muted">Camera and lens rental, certified operators, gaffers, and lighting crew ready to deploy.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container card">
+          <h2 class="section-title">Designed for collaboration</h2>
+          <p class="muted" style="max-width: 40rem;">
+            Whether you’re launching a product, reimagining a brand, or elevating a recurring show, we co-create the creative strategy and handle the technical execution.
+          </p>
+          <a class="btn btn-primary" href="book-now.html">Book a consultation</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <div class="footer-brand">Trois Six Neuf</div>
+          <p class="muted">Casablanca's high-end creative and production boutique studio.</p>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <p class="muted">36 Rue de la Réunion, Casablanca</p>
+        </div>
+        <div>
+          <h4>Quick Links</h4>
+          <div class="footer-links">
+            <a href="studio-spaces.html">Studio Spaces</a>
+            <a href="creative-services.html">Services</a>
+            <a href="book-now.html">Book Now</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h4>Connect</h4>
+          <div class="social-links">
+            <a href="https://www.instagram.com/trois.six.neuf" target="_blank" rel="noreferrer">Instagram</a>
+            <a href="mailto:trois6neuf.studio@gmail.com">Email</a>
+          </div>
+          <a href="book-now.html" class="muted" style="display: inline-block; margin-top: 0.8rem;">Booking Policy</a>
+        </div>
+      </div>
+      <div class="container footer-bottom">
+        <span>© <span id="year"></span> Trois Six Neuf Studio.</span>
+        <span>Crafted for creators in Casablanca.</span>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Service",
+        "name": "Trois Six Neuf Creative Services",
+        "provider": {
+          "@type": "Organization",
+          "name": "Trois Six Neuf Studio"
+        },
+        "areaServed": {
+          "@type": "City",
+          "name": "Casablanca"
+        },
+        "serviceType": [
+          "Content creation support",
+          "Visual identity design",
+          "Audio post-production",
+          "Set design and styling",
+          "Production crew and rentals"
+        ]
+      }
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Creative Production Studio Casablanca | Trois Six Neuf</title>
+    <meta
+      name="description"
+      content="Discover Trois Six Neuf — a boutique studio offering cyclorama, podcast, and kitchen production spaces with cinematic equipment in Casablanca."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%23D42027'/%3E%3Ctext x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-family='Space Grotesk' font-size='28' fill='%23fff'%3E369%3C/text%3E%3C/svg%3E" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a href="index.html" class="brand">Trois Six Neuf</a>
+        <nav aria-label="Primary">
+          <ul id="primary-menu" class="nav-links">
+            <li><a class="active" href="index.html">Home</a></li>
+            <li><a href="studio-spaces.html">Studio Spaces</a></li>
+            <li><a href="creative-services.html">Creative Services</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="book-now.html">Book Now</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <a class="btn btn-primary" href="book-now.html">Book a Session</a>
+        <button class="hamburger" aria-label="Toggle navigation" aria-controls="primary-menu" aria-expanded="false">
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div
+          class="hero-visual"
+          style="background-image: url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1500&q=80');"
+          aria-hidden="true"
+        ></div>
+        <div class="hero-content" data-animate>
+          <div class="badge">Boutique Creative &amp; Production Studio</div>
+          <h1>Where Creativity Meets Control.</h1>
+          <p>
+            High-spec studio environments and modular workflows, purpose-built in Casablanca for filmmakers, brands, chefs, podcasters, and creators ready to own their narrative.
+          </p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="studio-spaces.html">Explore the Studios</a>
+            <a class="btn btn-outline" href="book-now.html">Book Now</a>
+          </div>
+        </div>
+        <div class="scroll-indicator" aria-hidden="true"></div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container split-grid">
+          <div>
+            <h2 class="section-title">Casablanca's modular playground</h2>
+            <p class="muted">
+              Trois Six Neuf is a precision-built studio ecosystem offering cyclorama, podcast, and kitchen spaces under one roof. We engineered each zone to scale with your concepts — from agile social content to cinematic brand worlds.
+            </p>
+          </div>
+          <div class="card">
+            <div class="feature-list">
+              <div class="feature">
+                <div class="icon-circle"><span>◐</span></div>
+                <h3>Cyclorama Studio</h3>
+                <p class="muted">Infinity curve, 360° lighting rail, and chroma-ready for video, photo, or XR.</p>
+              </div>
+              <div class="feature">
+                <div class="icon-circle"><span>✦</span></div>
+                <h3>Podcast Capsule</h3>
+                <p class="muted">Soundproof, multi-cam enabled, ready for live-stream and post-production.</p>
+              </div>
+              <div class="feature">
+                <div class="icon-circle"><span>△</span></div>
+                <h3>Cuisine Lab</h3>
+                <p class="muted">Culinary stage with controlled lighting and modular rigs for food storytelling.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section parallax-section" data-animate>
+        <div class="container">
+          <h2 class="section-title">Why creators choose trois six neuf</h2>
+          <div class="split-grid">
+            <div class="card">
+              <h3>Performance infrastructure</h3>
+              <p class="muted">Industrial-grade power, acoustic treatment, and climate-controlled comfort keep your crew focused.</p>
+            </div>
+            <div class="card">
+              <h3>Cinematic results</h3>
+              <p class="muted">A lighting-first philosophy with programmable LEDs, modifiers, and seamless rigging.</p>
+            </div>
+            <div class="card">
+              <h3>Workflow obsessed</h3>
+              <p class="muted">Modular layouts, pre-light options, and crew support tailored for fast turnarounds.</p>
+            </div>
+            <div class="card">
+              <h3>Creative partnership</h3>
+              <p class="muted">From pre-production to delivery, our team is ready to co-design your production journey.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container">
+          <h2 class="section-title">Trusted by bold brands</h2>
+          <div class="grid-logos">
+            <div class="logo-tile">Maison Atlas</div>
+            <div class="logo-tile">Casablanca Labs</div>
+            <div class="logo-tile">Noir Stories</div>
+            <div class="logo-tile">Studio Mirage</div>
+            <div class="logo-tile">Waveform</div>
+            <div class="logo-tile">Gastronoir</div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container card" style="text-align: center;">
+          <h2 class="section-title">Ready to create?</h2>
+          <p class="muted" style="max-width: 38rem; margin: 0 auto 2rem;">
+            Secure your time on the cyclorama, podcast suite, or kitchen set. Our coordinators will tailor equipment lists, crew, and hospitality to your production.
+          </p>
+          <a class="btn btn-primary" href="book-now.html">Book Your Space</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <div class="footer-brand">Trois Six Neuf</div>
+          <p class="muted">Casablanca's high-end creative and production boutique studio.</p>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <p class="muted">36 Rue de la Réunion, Casablanca</p>
+        </div>
+        <div>
+          <h4>Quick Links</h4>
+          <div class="footer-links">
+            <a href="studio-spaces.html">Studio Spaces</a>
+            <a href="creative-services.html">Services</a>
+            <a href="book-now.html">Book Now</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h4>Connect</h4>
+          <div class="social-links">
+            <a href="https://www.instagram.com/trois.six.neuf" target="_blank" rel="noreferrer">Instagram</a>
+            <a href="mailto:trois6neuf.studio@gmail.com">Email</a>
+          </div>
+          <a href="book-now.html" class="muted" style="display: inline-block; margin-top: 0.8rem;">Booking Policy</a>
+        </div>
+      </div>
+      <div class="container footer-bottom">
+        <span>© <span id="year"></span> Trois Six Neuf Studio.</span>
+        <span>Crafted for creators in Casablanca.</span>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "LocalBusiness",
+        "name": "Trois Six Neuf Studio",
+        "image": "https://www.instagram.com/trois.six.neuf/",
+        "url": "https://www.instagram.com/trois.six.neuf",
+        "telephone": "+212522204315",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "36 Rue de la Réunion",
+          "addressLocality": "Casablanca",
+          "addressCountry": "MA"
+        },
+        "priceRange": "$$$",
+        "description": "Boutique creative production studio with cyclorama, podcast, and kitchen sets in Casablanca.",
+        "sameAs": ["https://www.instagram.com/trois.six.neuf"]
+      }
+    </script>
+  </body>
+</html>

--- a/studio-spaces.html
+++ b/studio-spaces.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rent a Cyclorama, Podcast or Kitchen Studio in Casablanca</title>
+    <meta
+      name="description"
+      content="Explore our modular, high-performance studio environments built for creators."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a href="index.html" class="brand">Trois Six Neuf</a>
+        <nav aria-label="Primary">
+          <ul id="primary-menu" class="nav-links">
+            <li><a href="index.html">Home</a></li>
+            <li><a class="active" href="studio-spaces.html">Studio Spaces</a></li>
+            <li><a href="creative-services.html">Creative Services</a></li>
+            <li><a href="about.html">About</a></li>
+            <li><a href="book-now.html">Book Now</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+        <a class="btn btn-primary" href="book-now.html">Book a Session</a>
+        <button class="hamburger" aria-label="Toggle navigation" aria-controls="primary-menu" aria-expanded="false">
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" style="min-height: 70vh;">
+        <div
+          class="hero-visual"
+          style="background-image: url('https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=1500&q=80');"
+          aria-hidden="true"
+        ></div>
+        <div class="hero-content" data-animate>
+          <div class="badge">Spaces engineered for impact</div>
+          <h1>Studios tuned for cinematic output</h1>
+          <p>
+            Choose the environment that unlocks your best work. From immersive cyclorama builds to soundstage podcasting and chef-ready kitchen rigs, Trois Six Neuf delivers precision, comfort, and control.
+          </p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="book-now.html">View availability</a>
+            <a class="btn btn-outline" href="creative-services.html">Add creative support</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container studio-grid">
+          <article class="studio">
+            <div class="studio-visual">
+              <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80" alt="Cyclorama studio lighting" />
+            </div>
+            <div>
+              <h3>Cyclorama Studio</h3>
+              <p>
+                A 6x4m infinity curve with matte white and chroma options, wrapped in a 360° lighting rail for quick rigging and creative lighting setups.
+              </p>
+              <ul class="feature-list">
+                <li>Modular flooring for vehicles, product sets, or green screen</li>
+                <li>Pre-lit presets and DMX programmable LED grid</li>
+                <li>Integrated tether stations, power distribution, and blackout</li>
+              </ul>
+              <a class="btn btn-primary" href="book-now.html">View Pricing &amp; Availability</a>
+            </div>
+          </article>
+
+          <article class="studio" data-animate>
+            <div class="studio-visual">
+              <img src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=1200&q=80" alt="Podcast recording setup" />
+            </div>
+            <div>
+              <h3>Podcast Studio</h3>
+              <p>
+                A soundproof capsule with luxurious finishes, perfect for multi-camera shows, intimate interviews, or live-stream events.
+              </p>
+              <ul class="feature-list">
+                <li>4-mic array with broadcast preamps and monitoring</li>
+                <li>Acoustic treatment, mood lighting, and large-format display</li>
+                <li>Full-day, half-day, or express session options</li>
+              </ul>
+              <a class="btn btn-primary" href="book-now.html">View Pricing &amp; Availability</a>
+            </div>
+          </article>
+
+          <article class="studio" data-animate>
+            <div class="studio-visual">
+              <img src="https://images.unsplash.com/photo-1504753793650-d4a2b783c15e?auto=format&fit=crop&w=1200&q=80" alt="Kitchen studio with plating area" />
+            </div>
+            <div>
+              <h3>Kitchen Studio</h3>
+              <p>
+                Culinary storytelling elevated with temperature-controlled lighting, prep islands, and modular camera rigs for every angle.
+              </p>
+              <ul class="feature-list">
+                <li>Chef-grade appliances and interchangeable worktops</li>
+                <li>Overhead rigging for motion-control and top-down shots</li>
+                <li>Dedicated food styling zone and prop library</li>
+              </ul>
+              <a class="btn btn-primary" href="book-now.html">View Pricing &amp; Availability</a>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="section" data-animate>
+        <div class="container">
+          <h2 class="section-title">Hybrid &amp; bundle packages</h2>
+          <p class="muted" style="max-width: 40rem;">
+            Combine spaces to match your production agenda. Move seamlessly from scene to interview to culinary capture without losing momentum.
+          </p>
+          <div class="package-grid" style="margin-top: 2.5rem;">
+            <div class="package-card">
+              <h3>Cyclorama + Podcast</h3>
+              <p class="muted">Split your day across the cyclorama for hero visuals and the podcast capsule for conversation-led content.</p>
+              <a class="btn btn-outline" href="book-now.html">Reserve bundle</a>
+            </div>
+            <div class="package-card">
+              <h3>Cyclorama + Cuisine</h3>
+              <p class="muted">Flow between product storytelling and culinary artistry with coordinated lighting presets and crew.</p>
+              <a class="btn btn-outline" href="book-now.html">Reserve bundle</a>
+            </div>
+            <div class="package-card">
+              <h3>Full-day creative</h3>
+              <p class="muted">Access all environments with dedicated support, live switching, and hospitality for extended productions.</p>
+              <a class="btn btn-outline" href="book-now.html">Reserve bundle</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <div class="footer-brand">Trois Six Neuf</div>
+          <p class="muted">Casablanca's high-end creative and production boutique studio.</p>
+        </div>
+        <div>
+          <h4>Visit</h4>
+          <p class="muted">36 Rue de la Réunion, Casablanca</p>
+        </div>
+        <div>
+          <h4>Quick Links</h4>
+          <div class="footer-links">
+            <a href="studio-spaces.html">Studio Spaces</a>
+            <a href="creative-services.html">Services</a>
+            <a href="book-now.html">Book Now</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h4>Connect</h4>
+          <div class="social-links">
+            <a href="https://www.instagram.com/trois.six.neuf" target="_blank" rel="noreferrer">Instagram</a>
+            <a href="mailto:trois6neuf.studio@gmail.com">Email</a>
+          </div>
+          <a href="book-now.html" class="muted" style="display: inline-block; margin-top: 0.8rem;">Booking Policy</a>
+        </div>
+      </div>
+      <div class="container footer-bottom">
+        <span>© <span id="year"></span> Trois Six Neuf Studio.</span>
+        <span>Crafted for creators in Casablanca.</span>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "Trois Six Neuf Studio Rentals",
+        "brand": {
+          "@type": "Brand",
+          "name": "Trois Six Neuf"
+        },
+        "description": "Cyclorama, podcast, and kitchen studio rentals with modular packages in Casablanca.",
+        "offers": [
+          {
+            "@type": "Offer",
+            "name": "Cyclorama Studio Day",
+            "priceCurrency": "MAD",
+            "availability": "https://schema.org/InStock"
+          },
+          {
+            "@type": "Offer",
+            "name": "Podcast Studio Session",
+            "priceCurrency": "MAD",
+            "availability": "https://schema.org/InStock"
+          },
+          {
+            "@type": "Offer",
+            "name": "Kitchen Studio Day",
+            "priceCurrency": "MAD",
+            "availability": "https://schema.org/InStock"
+          }
+        ]
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a multi-page marketing site for Trois Six Neuf with home, studio spaces, services, about, booking, and contact pages
- implement boutique-inspired styling, responsive navigation, and interactive animations across the experience
- embed booking calendar, FAQ schema, LocalBusiness/Product structured data, and contact integrations for conversions

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d54d8a9988832dbae1550210415883